### PR TITLE
Remove unused imports from `MainActivity.kt`

### DIFF
--- a/app/src/main/java/com/project/affirmations/MainActivity.kt
+++ b/app/src/main/java/com/project/affirmations/MainActivity.kt
@@ -12,27 +12,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
-import android.content.Intent
-import android.widget.Toast
-import androidx.lifecycle.ViewModel
-import kotlinx.coroutines.Dispatchers
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.project.affirmations.data.Datasource
 import com.project.affirmations.model.Affirmation
 import com.project.affirmations.ui.theme.AffirmationsTheme
-import androidx.compose.foundation.layout.Column
-import androidx.compose.ui.Modifier
-import androidx.activity.compose.rememberLauncherForActivityResult
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
Cleaned up the `MainActivity.kt` file by removing all unused import statements to improve code readability and maintainability. No functional changes were made.

please accept it under `hactoberfest`

#6 